### PR TITLE
Add Cypress CLI step

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 'lts/*'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: CI Exemplo
-        uses: cypress-io/github-action@v6
+      - name: Run Cypress tests
+        run: npx cypress run


### PR DESCRIPTION
## Summary
- run reproducible install with `npm ci`
- add explicit step running `npx cypress run`

## Testing
- `npm run cypress:run` *(fails: Cypress not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68404d204750832ba8763ecc3431633b